### PR TITLE
V srvasu/feedback config enduser

### DIFF
--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus.Configuration/Controllers/HomeController.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus.Configuration/Controllers/HomeController.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Configuration.Controllers
     using Microsoft.Azure.CognitiveServices.Knowledge.QnAMaker;
     using Microsoft.Teams.Apps.FAQPlusPlus.Common.Models;
     using Microsoft.Teams.Apps.FAQPlusPlus.Common.Providers;
-
+    
     /// <summary>
     /// Home Controller
     /// </summary>

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus.Configuration/Controllers/HomeController.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus.Configuration/Controllers/HomeController.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Configuration.Controllers
         public async Task<ActionResult> ParseAndSaveFeedbackTeamIdAsync(string feedbackTeamId = "")
         {
             string feedbackTeamIdAfterParse = ParseTeamIdFromDeepLink(feedbackTeamId ?? string.Empty);
-            if (string.IsNullOrWhiteSpace(feedbackTeamId))
+            if (string.IsNullOrWhiteSpace(feedbackTeamIdAfterParse))
             {
                 return new HttpStatusCodeResult(HttpStatusCode.BadRequest, "The provided team id is not valid");
             }

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus.Configuration/Controllers/HomeController.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus.Configuration/Controllers/HomeController.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Configuration.Controllers
         }
 
         /// <summary>
-        /// Parse team id from first and then proceed to save it on success.
+        /// Parse team id from the configuration web app and then proceed to save it to the azure table on success.
         /// </summary>
         /// <param name="feedbackTeamId">Feedback Team id is the unique string.</param>
         /// <returns>View.</returns>

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Bots/FaqPlusPlusBot.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Bots/FaqPlusPlusBot.cs
@@ -788,7 +788,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Bots
                     break;
 
                 case Constants.ShareFeedback:
-                    if (this.configurationProvider.GetSavedEntityDetailAsync(ConfigurationEntityTypes.FeedbackTeamId).Equals(string.Empty))
+                    if (string.IsNullOrEmpty(await this.configurationProvider.GetSavedEntityDetailAsync(ConfigurationEntityTypes.FeedbackTeamId).ConfigureAwait(false)))
                     {
                         this.logger.LogInformation("Feedback Team ID not registered yet.");
                         await turnContext.SendActivityAsync(MessageFactory.Text("I'm sorry, feedback team has not been registered yet."));

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Bots/FaqPlusPlusBot.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Bots/FaqPlusPlusBot.cs
@@ -788,10 +788,10 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Bots
                     break;
 
                 case Constants.ShareFeedback:
-                    if (string.IsNullOrEmpty(await this.configurationProvider.GetSavedEntityDetailAsync(ConfigurationEntityTypes.FeedbackTeamId).ConfigureAwait(false)))
+                    if (string.IsNullOrEmpty(await this.configurationProvider.GetSavedEntityDetailAsync(ConfigurationEntityTypes.FeedbackTeamId)) == true)
                     {
                         this.logger.LogInformation("Feedback Team ID not registered yet.");
-                        await turnContext.SendActivityAsync(MessageFactory.Text("I'm sorry, feedback team has not been registered yet."));
+                        await turnContext.SendActivityAsync(MessageFactory.Text("I'm sorry, feedback team has not been registered yet.", "I'm sorry, feedback team has not been registered yet."), cancellationToken).ConfigureAwait(false);
                         break;
                     }
                     else

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Bots/FaqPlusPlusBot.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Bots/FaqPlusPlusBot.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Bots
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
     using Microsoft.Azure.CognitiveServices.Knowledge.QnAMaker.Models;
     using Microsoft.Bot.Builder;
     using Microsoft.Bot.Builder.Teams;
@@ -32,7 +31,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Bots
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using ErrorResponseException = Microsoft.Azure.CognitiveServices.Knowledge.QnAMaker.Models.ErrorResponseException;
-    
+
 
     /// <summary>
     /// Class that handles the teams activity of Faq Plus bot and messaging extension.
@@ -749,14 +748,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Bots
                 var botDisplayName = turnContext.Activity.Recipient.Name;
                 var teamWelcomeCardAttachment = WelcomeTeamCard.GetCard();
                 var teamWelcomeFeedbackCardAttachment = WelcomeFeedbackTeamCard.GetCard();
-                /*if (teamDetails.Team.Name.Contains(Strings.FeedbackCheckOne) || teamDetails.Team.Name.Contains(Strings.FeedbackCheckTwo))
-                {
-                    await this.SendCardToTeamAsync(turnContext, teamWelcomeFeedbackCardAttachment, teamDetails.Team.Id, cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    await this.SendCardToTeamAsync(turnContext, teamWelcomeCardAttachment, teamDetails.Team.Id, cancellationToken).ConfigureAwait(false);
-                }*/
+                // We compare expertID obtained from the Azure table which was obtained from the configuration web app with the ID of the team in which the bot was added to.
                 if (teamDetails.Team.Id == expertID)
                 {
                     await this.SendCardToTeamAsync(turnContext, teamWelcomeCardAttachment, teamDetails.Team.Id, cancellationToken).ConfigureAwait(false);
@@ -800,7 +792,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Bots
                     if (string.IsNullOrEmpty(await this.configurationProvider.GetSavedEntityDetailAsync(ConfigurationEntityTypes.FeedbackTeamId).ConfigureAwait(false)))
                     {
                         this.logger.LogInformation("Feedback Team ID not registered yet.");
-                        await turnContext.SendActivityAsync(MessageFactory.Text(Strings.FeedbackTeamUnregisteredMessage, Strings.FeedbackTeamUnregisteredMessage), cancellationToken).ConfigureAwait(false);
+                        await turnContext.SendActivityAsync(MessageFactory.Text(Strings.FeedbackTeamUnregisteredMessage), cancellationToken).ConfigureAwait(false);
                         break;
                     }
                     else

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Bots/FaqPlusPlusBot.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Bots/FaqPlusPlusBot.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Bots
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using ErrorResponseException = Microsoft.Azure.CognitiveServices.Knowledge.QnAMaker.Models.ErrorResponseException;
+    
 
     /// <summary>
     /// Class that handles the teams activity of Faq Plus bot and messaging extension.
@@ -787,9 +788,18 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Bots
                     break;
 
                 case Constants.ShareFeedback:
-                    this.logger.LogInformation("Sending user feedback card");
-                    await turnContext.SendActivityAsync(MessageFactory.Attachment(ShareFeedbackCard.GetCard())).ConfigureAwait(false);
-                    break;
+                    if (this.configurationProvider.GetSavedEntityDetailAsync(ConfigurationEntityTypes.FeedbackTeamId).Equals(string.Empty))
+                    {
+                        this.logger.LogInformation("Feedback Team ID not registered yet.");
+                        await turnContext.SendActivityAsync(MessageFactory.Text("I'm sorry, feedback team has not been registered yet."));
+                        break;
+                    }
+                    else
+                    {
+                        this.logger.LogInformation("Sending user feedback card");
+                        await turnContext.SendActivityAsync(MessageFactory.Attachment(ShareFeedbackCard.GetCard())).ConfigureAwait(false);
+                        break;
+                    }
 
                 case Constants.TakeATour:
                     this.logger.LogInformation("Sending user tour card");

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Properties/Strings.Designer.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Properties/Strings.Designer.cs
@@ -439,6 +439,15 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to I&apos;m sorry, feedback team has not been registered yet..
+        /// </summary>
+        public static string FeedbackTeamUnregisteredMessage {
+            get {
+                return ResourceManager.GetString("FeedbackTeamUnregisteredMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Tell my team of experts how I&apos;m doing so they can help me improve..
         /// </summary>
         public static string FeedbackText1 {

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Properties/Strings.Designer.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Properties/Strings.Designer.cs
@@ -439,7 +439,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to I&apos;m sorry, feedback team has not been registered yet..
+        ///   Looks up a localized string similar to I&apos;m sorry, I don&apos;t think I can find the Team ID for submitting Feedback..
         /// </summary>
         public static string FeedbackTeamUnregisteredMessage {
             get {

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Properties/Strings.resx
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Properties/Strings.resx
@@ -607,7 +607,7 @@ I am your friendly share feedback bot! I will take your feedback and send it to 
     <comment>Check if it's a feedback team or not</comment>
   </data>
   <data name="FeedbackTeamUnregisteredMessage" xml:space="preserve">
-    <value>I'm sorry, feedback team has not been registered yet.</value>
+    <value>I'm sorry, I don't think I can find the Team ID for submitting Feedback.</value>
     <comment>If the user asks for feedback when the feedback team has not been configured, the bot will return this message.</comment>
   </data>
 </root>

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Properties/Strings.resx
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Properties/Strings.resx
@@ -606,4 +606,8 @@ I am your friendly share feedback bot! I will take your feedback and send it to 
     <value>feedback</value>
     <comment>Check if it's a feedback team or not</comment>
   </data>
+  <data name="FeedbackTeamUnregisteredMessage" xml:space="preserve">
+    <value>I'm sorry, feedback team has not been registered yet.</value>
+    <comment>If the user asks for feedback when the feedback team has not been configured, the bot will return this message.</comment>
+  </data>
 </root>


### PR DESCRIPTION
Bifurcated the ask an expert and share feedback channels, added user notification if the share feedback ID has not been registered and added the condition to check if the side-loaded team is experts or share feedback.